### PR TITLE
docs: Fix simple typo, maximun -> maximum

### DIFF
--- a/src/List/maximum.js
+++ b/src/List/maximum.js
@@ -1,5 +1,5 @@
 import maximumBy from './maximumBy'
 import id from '../General/id'
 
-// + maximun :: [Number] -> Number
+// + maximum :: [Number] -> Number
 export default maximumBy(id)

--- a/src/List/minimum.js
+++ b/src/List/minimum.js
@@ -1,5 +1,5 @@
 import minimumBy from './minimumBy'
 import id from '../General/id'
 
-// + maximum :: [Number] -> Number
+// + minimum :: [Number] -> Number
 export default minimumBy(id)

--- a/src/List/minimum.js
+++ b/src/List/minimum.js
@@ -1,5 +1,5 @@
 import minimumBy from './minimumBy'
 import id from '../General/id'
 
-// + maximun :: [Number] -> Number
+// + maximum :: [Number] -> Number
 export default minimumBy(id)


### PR DESCRIPTION
There is a small typo in src/List/maximum.js, src/List/minimum.js.

Should read `maximum` rather than `maximun`.

