### PR TITLE
build(jsr): include .d.ts files in JSR publish config

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -5,7 +5,8 @@
     "include": [
       "LICENSE",
       "README.md",
-      "src/**/*.js"
+      "src/**/*.js",
+      "src/**/*.d.ts"
     ]
   },
   "exports": {


### PR DESCRIPTION
Adds src/**/*.d.ts to JSR publish include files. This ensures that referenced declaration files are included in the package module graph, resolving excluded-module publishing errors.