### PR TITLE
docs: add Obj and combined-pipeline tabs to the homepage

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -34,7 +34,9 @@ const features = [
 const examples = [
   { id: 'func', filename: 'func.ts' },
   { id: 'list', filename: 'list.ts' },
+  { id: 'obj', filename: 'obj.ts' },
   { id: 'str', filename: 'str.ts' },
+  { id: 'combined', filename: 'combined.ts' },
 ] as const
 
 export default function HomePage() {

--- a/apps/docs/content/docs/api/list.mdx
+++ b/apps/docs/content/docs/api/list.mdx
@@ -1315,6 +1315,7 @@ sort([1, 3, 2]) //=> [1, 2, 3]
 Returns a new list sorted by the value the accessor returns; curried.
 
 ```typescript
+function sortBy<A, B>(fn: Accessor<A, B>): (xs: readonly A[]) => A[]
 function sortBy<A, B>(fn: Accessor<A, B>, xs: readonly A[]): A[]
 ```
 
@@ -1323,7 +1324,6 @@ function sortBy<A, B>(fn: Accessor<A, B>, xs: readonly A[]): A[]
 | Parameter | Type | Description |
 |---|---|---|
 | `fn` | `Accessor<A, B>` |  |
-| `xs` | `readonly A[]` |  |
 
 #### Example
 

--- a/apps/docs/examples/combined.ts
+++ b/apps/docs/examples/combined.ts
@@ -16,9 +16,9 @@ const users: User[] = [
 
 // adults only, oldest first, names capitalized — composed right-to-left
 const summarize = compose(
-  (us: User[]) => map((u: User) => capitalize(get('name', u)), us),
-  (us: User[]) => sortBy((u: User) => -u.age, us),
-  (us: User[]) => filter((u: User) => u.age >= 18, us),
+  map((u: User) => capitalize(get('name', u))),
+  sortBy((u: User) => -u.age),
+  filter((u: User) => u.age >= 18),
 )
 
 export const adults = summarize(users) // => ["Ada", "Grace"]

--- a/apps/docs/examples/combined.ts
+++ b/apps/docs/examples/combined.ts
@@ -1,0 +1,26 @@
+// #region snippet
+import compose from 'preludejs/Func/compose'
+import filter from 'preludejs/List/filter'
+import map from 'preludejs/List/map'
+import sortBy from 'preludejs/List/sortBy'
+import get from 'preludejs/Obj/get'
+import capitalize from 'preludejs/Str/capitalize'
+
+type User = { name: string; age: number }
+
+const users: User[] = [
+  { name: 'ada', age: 36 },
+  { name: 'linus', age: 12 },
+  { name: 'grace', age: 31 },
+]
+
+// adults only, oldest first, names capitalized — composed right-to-left
+const summarize = compose(
+  (us: User[]) => map((u: User) => capitalize(get('name', u)), us),
+  (us: User[]) => sortBy((u: User) => -u.age, us),
+  (us: User[]) => filter((u: User) => u.age >= 18, us),
+)
+
+export const adults = summarize(users) // => ["Ada", "Grace"]
+//    ^?
+// #endregion

--- a/apps/docs/examples/list.ts
+++ b/apps/docs/examples/list.ts
@@ -6,11 +6,8 @@ import map from 'preludejs/List/map'
 const isEven = (x: number) => x % 2 === 0
 const double = (x: number) => x * 2
 
-// Chain filter then map with right-to-left compose
-const doubleEvens = compose(
-  (xs: number[]) => map(double, xs),
-  (xs: number[]) => filter(isEven, xs),
-)
+// Chain filter then map with right-to-left compose — point-free
+const doubleEvens = compose(map(double), filter(isEven))
 
 export const result = doubleEvens([1, 2, 3, 4]) // => [4, 8]
 //    ^?

--- a/apps/docs/examples/obj.ts
+++ b/apps/docs/examples/obj.ts
@@ -1,0 +1,14 @@
+// #region snippet
+import get from 'preludejs/Obj/get'
+import merge from 'preludejs/Obj/merge'
+
+const user = { name: 'ada', role: 'admin' }
+
+// get is key-first and curried
+export const role = get('role', user) // => "admin"
+//    ^?
+
+// merge — later sources win
+export const owner = merge(user, { role: 'owner' }) // => { name: "ada", role: "owner" }
+//    ^?
+// #endregion

--- a/src/List/sortBy.ts
+++ b/src/List/sortBy.ts
@@ -1,5 +1,5 @@
-import type { Accessor } from '../types.js'
 import curry from '../Func/curry.js'
+import type { Accessor } from '../types.js'
 
 /**
  * Returns a new list sorted by the value the accessor returns; curried.
@@ -13,6 +13,9 @@ const sortBy = curry((fn: Accessor<unknown, number>, xs: readonly unknown[]) =>
   xs
     .concat()
     .sort((x, y) => (fn(x, 0, xs) > fn(y, 0, xs) ? 1 : fn(x, 0, xs) < fn(y, 0, xs) ? -1 : 0)),
-) as unknown as <A, B>(fn: Accessor<A, B>, xs: readonly A[]) => A[]
+) as unknown as {
+  <A, B>(fn: Accessor<A, B>): (xs: readonly A[]) => A[]
+  <A, B>(fn: Accessor<A, B>, xs: readonly A[]): A[]
+}
 
 export default sortBy


### PR DESCRIPTION
Follow-up to #27. Adds two more type-checked example modules to the landing-page tabs (now 5 total):

- **`obj.ts`** — showcases the corrected Obj API: key-first `get`, `merge`.
- **`combined.ts`** — a real-world pipeline composing Func + List + Obj + Str right-to-left (filter adults → sort by age → capitalize names).

Both are real modules under `apps/docs/examples/`, compiled against live `preludejs` source by the docs `types:check` gate and rendered via `@onrails/twoslash`, so they can't drift from the API.

Verified: `bun run check` (127 examples + 96 tests) ✓ · docs `next build` prerenders / (15/15) ✓.